### PR TITLE
Unify currency symbol display across UI using formatCurrencySymbol 

### DIFF
--- a/client/app/sharedLayouts/item-profile.tsx
+++ b/client/app/sharedLayouts/item-profile.tsx
@@ -13,6 +13,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Ionicons } from "@expo/vector-icons";
 import Toast from "react-native-toast-message";
 import ParallaxScrollView from "@/components/ui/ParallaxScrollView";
+import{ formatCurrencySymbol } from "@/utils/functions";
 
 const ItemProfileScreen = () => {
     const { id } = useLocalSearchParams<{ id: string }>();
@@ -135,7 +136,7 @@ const ItemProfileScreen = () => {
                             </Text>
                         </View>
                         <Text className='text-xl font-bold text-black'>
-                            {item.price} {item.currency}
+                            {item.price} {formatCurrencySymbol(item.currency)}
                         </Text>
                     </View>
                 </View>

--- a/client/app/sharedLayouts/transaction-details.tsx
+++ b/client/app/sharedLayouts/transaction-details.tsx
@@ -25,6 +25,7 @@ import {
 import { Transaction } from "@/services/interfaceService";
 import UserImage from "@/components/UserImage";
 import FloatingBackArrowButton from "@/components/ui/FloatingBackArrowButton";
+import { formatCurrencySymbol } from "@/utils/functions";
 
 export default function TransactionDetails() {
   const router = useRouter();
@@ -283,7 +284,7 @@ export default function TransactionDetails() {
           <Row label="Description" value={transaction.description || "-"} />
           <Row
             label="Amount"
-            value={`${transaction.amount} ${transaction.currency}`}
+            value={`${transaction.amount} ${formatCurrencySymbol(transaction.currency)}`}
           />
         </View>
 

--- a/client/app/sharedLayouts/transactions.tsx
+++ b/client/app/sharedLayouts/transactions.tsx
@@ -19,6 +19,8 @@ import { Feather } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
 import UserImage from '@/components/UserImage';
 import { currencies } from '@/utils/constants';
+import { formatCurrencySymbol } from '@/utils/functions';
+
 
 const PAGE_SIZE = 8;
 
@@ -135,8 +137,8 @@ const TransactionsPage = () => {
 				? item.customer?.name
 				: item.business?.name;
 
-		const currencySymbol = currencies.find(
-			(currency) => currency.code === item.currency)?.symbol || '₪';
+			const currencySymbol = formatCurrencySymbol(item.currency);
+
 
 		return (
 			<TouchableOpacity
@@ -177,7 +179,7 @@ const TransactionsPage = () => {
 				</View>
 				<Text className={`text-sm font-medium ${colorClass}`}>
 					{item.status === 'charged'
-						? `${item.charged}${currencySymbol}`
+						? `${item.charged} ${currencySymbol}`
 						: item.status.charAt(0).toUpperCase() + item.status.slice(1)}
 						</Text>
 			</TouchableOpacity>

--- a/client/utils/functions.ts
+++ b/client/utils/functions.ts
@@ -44,3 +44,16 @@ export const getBusinessCurrencySymbol = async () => {
 export const NormalizedImage = (
 	value: string | string[] | undefined
 ): string | undefined => (Array.isArray(value) ? value[0] : value);
+
+export const formatCurrencySymbol = (code: string): string => {
+	switch (code?.toUpperCase()) {
+	  case 'ILS':
+		return '₪';
+	  case 'USD':
+		return '$';
+	  case 'EUR':
+		return '€';
+	  default:
+		return code;
+	}
+  };  


### PR DESCRIPTION
Replaced raw currency codes with formatCurrencySymbol from utils/functions.ts for consistent symbol display across the app (₪, $, etc.).
Future symbols can easily be added via this utility.

